### PR TITLE
Removed 'free' from piracy detection.

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ async def on_message(message):
     return
   if hasattr(message.author, 'joined_at') and message.author.joined_at != None:
     if message.author.joined_at > datetime.now()-timedelta(days=3):
-      if any(w in message.content for w in ['pirate', 'torrent', 'free', 'pirating', 'piracy']):
+      if any(w in message.content for w in ['pirate', 'torrent', 'pirating', 'piracy']):
         await message.channel.send(embed=discord.Embed(title='Piracy Policy:', description="This message has been autosent because you seem new to this server:\n"+piracy))
         return
   for k, v in autoinfo.items():


### PR DESCRIPTION
This word has been the primary cause of false-positives and I haven't seen this word legitimately trigger the response.