### PR TITLE
Add Dolphin Bug lookup

### DIFF
--- a/categories/Search.py
+++ b/categories/Search.py
@@ -133,7 +133,7 @@ class Search(commands.Cog):
     '''
     Uses Dolphin Redmine to lookup bug reports
     '''
-    if (query.isdigit()):
+    if (query.isdecimal()):
         try:
             sea = requests.get(
               f'https://bugs.dolphin-emu.org/issues/{query}.json'

--- a/categories/Search.py
+++ b/categories/Search.py
@@ -124,6 +124,107 @@ class Search(commands.Cog):
   @lmgtfy.command(name='videos')
   async def lmgtfyvideos(self, ctx, *, query: str):
     await ctx.send(embed=discord.Embed(title='LMGTFY Videos:', description=f'<https://www.lmgtfy.com/search?t=v&q={urllib.parse.quote_plus(query)}>'))
+    
+  @commands.command(
+    help='Search for bugs with Dolphin Bug Reporter',
+    aliases=['b']
+  )
+  async def bugs(self, ctx, *, query: str):
+    '''
+    Uses Dolphin Redmine to lookup bug reports
+    '''
+    if (query.isdigit()):
+        try:
+            sea = requests.get(
+              f'https://bugs.dolphin-emu.org/issues/{query}.json'
+            ).json()['issue']
+        except ValueError:
+            await ctx.send('Sorry, your search could not be found.')
+            return
+
+        id = sea['id']
+        status = sea['status']['name']
+        author = sea['author']['name']
+        subject = sea['subject']
+        fixed = sea['custom_fields'][9]['value']
+        update = datetime.datetime.strptime(sea['updated_on'],"%Y-%m-%dT%H:%M:%SZ")
+
+        embed = discord.Embed(
+            title=f'**{subject}**',
+            url=f'https://bugs.dolphin-emu.org/issues/{id}',
+            color=0xFC2C03
+        )
+        embed.set_footer(
+          text='Report last modified',
+          icon_url='https://wiki.dolphin-emu.org/images/dolphin.40.png'
+        )
+        embed.set_author(
+          name='Dolphin Bug Reporter',
+          url='https://bugs.dolphin-emu.org/projects/emulator',
+          icon_url='https://wiki.dolphin-emu.org/images/dolphin.40.png'
+        )
+        embed.timestamp=update
+        embed.add_field(
+          name="Author:",
+          value=author,
+          inline=False
+        )
+        embed.add_field(
+          name="Status:",
+          value=status,
+          inline=False
+        )
+        if (fixed):
+          embed.add_field(
+            name="Fixed in:",
+            value=f'{fixed} | http://dolp.in/v{fixed}',
+            inline=False
+          )
+        await ctx.send(
+          f'**Bug report for:** ***{query}***:',
+          embed=embed
+        )
+
+    else:
+        sea=requests.get(
+            'https://bugs.dolphin-emu.org/projects/emulator/search.json?'
+            f'limit=3&all_words=1&open_issues=1&titles_only=&q="{query}"'
+        ).json()
+        hits = sea['total_count']
+        if not hits:
+            await ctx.send('Sorry, your search could not be found.')
+            return
+        if (hits > 3):
+            max = sea['limit']
+        else:
+            max = sea['total_count']
+        embed = discord.Embed(
+            title=f'**Bug Search Results**',
+            url='https://bugs.dolphin-emu.org/projects/emulator/search?'
+            f'limit=25&all_words=1&open_issues=1&titles_only=&q="{urllib.parse.quote_plus(query)}"',
+            color=0xFC2C03
+        )
+        embed.set_author(
+          name='Dolphin Bug Reporter',
+          url='https://bugs.dolphin-emu.org/projects/emulator',
+          icon_url='https://wiki.dolphin-emu.org/images/dolphin.40.png'
+        )
+        embed.set_footer(
+          text=f'Total results: {hits}',
+          icon_url='https://wiki.dolphin-emu.org/images/dolphin.40.png'
+        )
+        for x in range(max):
+           date = datetime.datetime.strptime(sea['results'][x]['datetime'],"%Y-%m-%dT%H:%M:%SZ")
+           url = sea['results'][x]['url']
+           embed.add_field(
+              name=sea['results'][x]['title'],
+              value=f'Date Reported: {date} | {url}',
+              inline=False
+            )
+        await ctx.send(
+          f'**Search result for:** ***"{query}"***:',
+          embed=embed
+        )
 
 
 def setup(bot):

--- a/categories/Search.py
+++ b/categories/Search.py
@@ -165,7 +165,7 @@ class Search(commands.Cog):
         )
         embed.timestamp=update
         embed.add_field(
-          name="Author:",
+          name="Reported by:",
           value=author,
           inline=False
         )


### PR DESCRIPTION
This PR adds functionality to find bug reports in Dolphin Redmine, by using a [hidden JSON API](https://www.redmine.org/projects/redmine/wiki/rest_api).
If a issue number is entered, it will find the information tied to the ID.
<img width="200" alt="Screen Shot 2020-12-13 at 1 13 01 PM" src="https://user-images.githubusercontent.com/39745188/102020124-1d630b00-3d45-11eb-8760-f4d9551fdd51.png">

If a non-number search is used, then it will show the top three results.
<img width="200" alt="Screen Shot 2020-12-13 at 1 16 34 PM" src="https://user-images.githubusercontent.com/39745188/102020189-75017680-3d45-11eb-912a-9e782ffbab6d.png">
In this instance, Redmine searches for the word "Vulkan" in issue titles, descriptions and comments.