### PR TITLE
Fixed logic in Search.py

### DIFF
--- a/categories/Search.py
+++ b/categories/Search.py
@@ -23,9 +23,9 @@ class Search(commands.Cog):
       ).json()['query']
       if sea['searchinfo']['totalhits'] != 0:
         break
-    else:
-      await ctx.send('Sorry, your search could not be found.')
-      return
+      else:
+        await ctx.send('Sorry, your search could not be found.')
+        return
     for x in range(len(sea['search'])):
       article = sea['search'][x]['title']
       req = requests.get(
@@ -35,9 +35,9 @@ class Search(commands.Cog):
       ).json()['query']['pages']
       if str(list(req)[0]) != "-1":
         break
-    else:
-      await ctx.send('Sorry, your search could not be found.')
-      return
+      else:
+        await ctx.send('Sorry, your search could not be found.')
+        return
     article = req[list(req)[0]]['title']
     arturl = req[list(req)[0]]['fullurl']
     lastedited = datetime.datetime.strptime(
@@ -57,7 +57,7 @@ class Search(commands.Cog):
       url=arturl,
       color=0x3FCAFF
     )
-    if starsfound != 0:
+    if starsfound != 0 and compatibility:
       embed.add_field(
         name="Compatibility:",
         value=':star:' * compatibility,


### PR DESCRIPTION
This fix provides two fixes for Search.py.

Search terms that were not found returns as an exception, instead of "Sorry, your search could not be found."
The if and else statements were not align with each other, so the script would try to access 'searchinfo' without being initialized.
Before:
![Screen Shot 2021-02-19 at 7 10 04 PM](https://user-images.githubusercontent.com/39745188/108574903-8be4bc00-72e6-11eb-8134-be50183bd7a9.png)
After:
![Screen Shot 2021-02-19 at 7 10 41 PM](https://user-images.githubusercontent.com/39745188/108574918-9606ba80-72e6-11eb-8852-c72f21d91883.png)

This also fixes compatibility logic when rating is zero stars.
On `value=':star:' * compatibility,` , if compatibility is 0, then on sending the embed, Discord.py would give 400 for not having a value. 
Before:
![Screen Shot 2021-02-19 at 7 10 11 PM](https://user-images.githubusercontent.com/39745188/108575240-8f2c7780-72e7-11eb-8fdc-860c033b88b9.png)
After:
![Screen Shot 2021-02-19 at 7 10 19 PM](https://user-images.githubusercontent.com/39745188/108575243-9489c200-72e7-11eb-80e4-b0b6924e0dc0.png)

Would it be better to have compatibility be a question mark if it is set to zero, or is it fine as is?  